### PR TITLE
Fix wrong property access on `Reference` instances

### DIFF
--- a/cablemap.core/cablemap/core/reader.py
+++ b/cablemap.core/cablemap/core/reader.py
@@ -608,10 +608,10 @@ def parse_references(content, year, reference_id=None, canonicalize=True):
             if origin == 'AND' and res and res[-1].is_cable():
                 last_origin = _REF_ORIGIN_PATTERN.match(res[-1].value).group(1)
                 origin = last_origin
-                enum = enum or res[-1].name
+                enum = enum or res[-1].value
             elif origin.startswith('AND') and res and res[-1].is_cable(): # for references like 09 FOO 1234 AND BAR 1234
                 origin = origin[3:]
-                enum = enum or res[-1].name
+                enum = enum or res[-1].value
             reference = u'%s%s%d' % (y, origin, int(sn))
             if canonicalize:
                 reference = canonicalize_id(reference)


### PR DESCRIPTION
This pull requests fixes the wrong property access for parsing references. The value  `res` contains `Reference` instances that have no name property defined. 
